### PR TITLE
ci: lint and build jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  lint:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.24.3"
+
+      - name: Go Mod Tidy
+        run: go mod tidy
+
+      - name: Go Lint
+        uses: golangci/golangci-lint-action@v7
+        with:
+          version: v2.1
+
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    needs: lint
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.24.3"
+
+      - name: Build Binary
+        run: go build -o gituser

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: goreleaser
 on:
   push:
     tags:
-      - '*'
+      - "*"
   workflow_dispatch:
 
 jobs:
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.24.3
 
       - name: Validate GoReleaser config
         uses: goreleaser/goreleaser-action@v2

--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -22,7 +22,10 @@ This command provides tools to:
 • Test SSH connections to GitHub and GitLab`,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Show help when no subcommand is provided
-		cmd.Help()
+		if err := cmd.Help(); err != nil {
+			logger.PrintError(err)
+			os.Exit(1)
+		}
 	},
 }
 

--- a/go.mod
+++ b/go.mod
@@ -18,4 +18,5 @@ require (
 	github.com/mattn/go-isatty v0.0.12 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	golang.org/x/sys v0.1.0 // indirect
+	golang.org/x/text v0.27.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,8 @@ golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.1.0 h1:kunALQeHf1/185U1i0GOB/fy1IPRDDpuoOOqRReG57U=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/text v0.27.0 h1:4fGWRpyh641NLlecmyl4LOe6yDdfaYNrGb2zdfo4JV4=
+golang.org/x/text v0.27.0/go.mod h1:1D28KMCvyooCX9hBiosv5Tz/+YLxj0j7XhWjpSUF7CU=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/internal/connectors/ssh/ssh.go
+++ b/internal/connectors/ssh/ssh.go
@@ -44,8 +44,7 @@ func (s *SSHConnector) AddKeyToAgent(keyPath string) error {
 		return fmt.Errorf("failed to start SSH agent: %w", err)
 	}
 
-	var cmd *exec.Cmd
-	cmd = exec.Command("ssh-add", keyPath)
+	cmd := exec.Command("ssh-add", keyPath)
 
 	output, err := cmd.CombinedOutput()
 	if err != nil {
@@ -61,8 +60,7 @@ func (s *SSHConnector) RemoveKeyFromAgent(keyPath string) error {
 		return nil
 	}
 
-	var cmd *exec.Cmd
-	cmd = exec.Command("ssh-add", "-d", keyPath)
+	cmd := exec.Command("ssh-add", "-d", keyPath)
 
 	output, err := cmd.CombinedOutput()
 	if err != nil {
@@ -78,8 +76,7 @@ func (s *SSHConnector) RemoveKeyFromAgent(keyPath string) error {
 }
 
 func (s *SSHConnector) ListKeysInAgent() ([]string, error) {
-	var cmd *exec.Cmd
-	cmd = exec.Command("ssh-add", "-L")
+	cmd := exec.Command("ssh-add", "-L")
 
 	output, err := cmd.CombinedOutput()
 	if err != nil {
@@ -102,8 +99,7 @@ func (s *SSHConnector) ListKeysInAgent() ([]string, error) {
 }
 
 func (s *SSHConnector) ClearAgent() error {
-	var cmd *exec.Cmd
-	cmd = exec.Command("ssh-add", "-D")
+	cmd := exec.Command("ssh-add", "-D")
 
 	output, err := cmd.CombinedOutput()
 	if err != nil {
@@ -158,7 +154,11 @@ func (s *SSHConnector) ValidateKeyPath(keyPath string) error {
 	if err != nil {
 		return fmt.Errorf("cannot open SSH key file: %w", err)
 	}
-	defer file.Close()
+	defer func() {
+		if err := file.Close(); err != nil {
+			fmt.Printf("Warning: failed to close file: %v\n", err)
+		}
+	}()
 
 	scanner := bufio.NewScanner(file)
 	if scanner.Scan() {

--- a/internal/format/str.go
+++ b/internal/format/str.go
@@ -1,0 +1,10 @@
+package format
+
+import (
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+)
+
+func TitleCase(s string) string {
+	return cases.Title(language.English).String(s)
+}

--- a/internal/services/setup_service.go
+++ b/internal/services/setup_service.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"fmt"
 	"go-gituser/internal/connectors/ssh"
+	"go-gituser/internal/format"
 	"go-gituser/internal/logger"
 	"go-gituser/internal/models"
 	"os"
@@ -235,7 +236,7 @@ func (s *SetupService) selectUserAccount(mode string) {
 }
 
 func (s *SetupService) askForGPGKey(mode string) bool {
-	fmt.Printf("\n🔑 GPG Key Setup for %s Account\n", strings.Title(mode))
+	fmt.Printf("\n🔑 GPG Key Setup for %s Account\n", format.TitleCase(mode))
 	fmt.Println("=====================================")
 
 	var useGPG string
@@ -249,7 +250,7 @@ func (s *SetupService) askForGPGKey(mode string) bool {
 }
 
 func (s *SetupService) setupSSHKeyForAccount(mode, email string, sshDiscovery ISSHDiscoveryService) string {
-	fmt.Printf("\n🔑 SSH Key Setup for %s Account\n", strings.Title(mode))
+	fmt.Printf("\n🔑 SSH Key Setup for %s Account\n", format.TitleCase(mode))
 	fmt.Println("=====================================")
 
 	// Ask if user wants to setup SSH

--- a/internal/services/ssh_discovery_service.go
+++ b/internal/services/ssh_discovery_service.go
@@ -146,7 +146,11 @@ func (s *SSHDiscoveryService) looksLikePrivateKey(filePath string) bool {
 	if err != nil {
 		return false
 	}
-	defer file.Close()
+	defer func() {
+		if err := file.Close(); err != nil {
+			fmt.Printf("Warning: failed to close file: %v\n", err)
+		}
+	}()
 
 	scanner := bufio.NewScanner(file)
 	if scanner.Scan() {


### PR DESCRIPTION
## Summary

This PR introduces a simple CI for linting and building go binary

## What’s in this PR?

- introduces `ci.yml` with a `lint` and `build` job.
- updates `release.yml` to use `go 1.24.3`.
